### PR TITLE
appveyor CI build

### DIFF
--- a/NppFavorites.sln
+++ b/NppFavorites.sln
@@ -8,7 +8,7 @@ Global
 		ANSI Debug|Win32 = ANSI Debug|Win32
 		ANSI Release|Win32 = ANSI Release|Win32
 		Unicode Debug|Win32 = Unicode Debug|Win32
-		Unicode Realeas|Win32 = Unicode Realeas|Win32
+		Unicode Release|Win32 = Unicode Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.ANSI Debug|Win32.ActiveCfg = ANSI Debug|Win32
@@ -17,8 +17,8 @@ Global
 		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.ANSI Release|Win32.Build.0 = ANSI Release|Win32
 		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Debug|Win32.ActiveCfg = Unicode Debug|Win32
 		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Debug|Win32.Build.0 = Unicode Debug|Win32
-		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Realeas|Win32.ActiveCfg = Unicode Realeas|Win32
-		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Realeas|Win32.Build.0 = Unicode Realeas|Win32
+		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Release|Win32.ActiveCfg = Unicode Release|Win32
+		{1590D7CD-7D3A-4AB7-A355-EE02F7FB987D}.Unicode Release|Win32.Build.0 = Unicode Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NppFavorites.vcxproj
+++ b/NppFavorites.vcxproj
@@ -13,8 +13,8 @@
       <Configuration>Unicode Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Unicode Realeas|Win32">
-      <Configuration>Unicode Realeas</Configuration>
+    <ProjectConfiguration Include="Unicode Release|Win32">
+      <Configuration>Unicode Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -28,7 +28,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -48,7 +48,7 @@
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
     <Import Project="no_ms.props" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
     <Import Project="no_ms.props" />
@@ -72,9 +72,9 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='ANSI Release|Win32'">.\bin\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='ANSI Release|Win32'">Release\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='ANSI Release|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'">.\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'">$(Configuration)\</IntDir>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">.\bin\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">false</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'">true</LinkIncremental>
@@ -125,7 +125,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Realeas|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>.\DockingFeature;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NppFavorites_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+version: 1.0.0.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+    - PlatformToolset: v120_xp
+    - PlatformToolset: v140_xp 
+
+platform:
+    #- x64
+    - Win32
+
+configuration:
+    - Unicode Debug
+    - Unicode Release
+
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild NppFavorites.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64") {
+            #Push-AppveyorArtifact "bin\$($env:CONFIGURATION)_$($env:PLATFORM)\NppFavorites.dll" -FileName NppFavorites.dll
+        }
+
+        if ($env:PLATFORM -eq "Win32" ) {
+            #Push-AppveyorArtifact "bin\$($env:CONFIGURATION)_$($env:PLATFORM)\NppFavorites.dll" -FileName NppFavorites.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v120_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "NppFavorites_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName bin\$env:CONFIGURATION_$env:PLATFORM\NppFavorites.dll
+            }
+            if($env:PLATFORM -eq "Win32"){
+            $ZipFileName = "NppFavorites_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName bin\$env:CONFIGURATION_$env:PLATFORM\NppFavorites.dll
+            }
+        }
+
+artifacts:
+  - path: NppFavorites_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v120_xp
+        configuration: Release


### PR DESCRIPTION
- initial appveyor.yml CI configuration, see https://ci.appveyor.com/project/chcg/nppfavorites/build/1.0.0.1 for vs2013 and vs2015 and the unicode version of the plugin
- corrected typo -> Unicode Release
- not configured yet: ansi builds, artifact publishing, github deployment

- what about updating to https://github.com/npp-plugins/plugintemplate v3.1 and dropping ansi support in favour of x64 like donho did?

- see e.g. https://github.com/pnedev/compare-plugin/releases/tag/v2.0.0 how release could look like with automatic deployment from appveyor to github